### PR TITLE
Change hardcoded sandbox key to be fallback only

### DIFF
--- a/src/context/store.tsx
+++ b/src/context/store.tsx
@@ -75,7 +75,7 @@ const StoreContextProvider = ({
       },
       apiUrl: environmentType?.toLowerCase() === 'testing' ? TEST_URL : API_URL,
       apiKey:
-        environmentType?.toLowerCase() === 'testing' ? SANDBOX_KEY : apiKey,
+        environmentType?.toLowerCase() === 'testing' && !apiKey ? SANDBOX_KEY : apiKey,
       route,
       searchQuery,
     }),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* The `SANDBOX_KEY` is now only applied when no `apiKey` is specified in the configuration.
* This applies only when the `environmentType` is set to `testing`.

## Related Issue

Fix #8 

## How Has This Been Tested?

Tested in https://github.com/hlxsites/aem-boilerplate-commerce/pull/18

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
